### PR TITLE
Support XDG directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq (,$(findstring clang,$(CXX)))
 	CXX_FLAGS += -stdlib=libc++
 endif
 
-LD_FLAGS += -luuid -lssl -lcrypto -ldl
+LD_FLAGS += -luuid -lssl -lcrypto -ldl -lboost_filesystem
 
 CXX_FLAGS += -Icpp-httplib
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifneq (,$(findstring clang,$(CXX)))
 	CXX_FLAGS += -stdlib=libc++
 endif
 
-LD_FLAGS += -luuid -lssl -lcrypto -ldl -lboost_filesystem
+LD_FLAGS += -luuid -lssl -lcrypto -ldl
 
 CXX_FLAGS += -Icpp-httplib
 

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -16,6 +16,7 @@ const size_t MIN_DATA_VERSION = 4;
 const size_t DATA_VERSION     = 6;
 
 std::string home_folder();
+std::string config_file();
 std::string budget_folder();
 std::string path_to_home_file(const std::string& file);
 std::string path_to_budget_file(const std::string& file);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -131,6 +131,16 @@ bool budget::load_config() {
         return false;
     }
 
+    fs::path config_home;
+    if(auto xdg_config_home = std::getenv("XDG_CONFIG_HOME")) {
+        config_home = fs::path{xdg_config_home};
+    } else {
+        config_home = fs::path{home_folder()} / ".config";
+    }
+    if(!load_configuration((config_home / "budget" / "budgetrc").string(), configuration)) {
+        return false;
+    }
+
     if(!verify_folder()){
         return false;
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -26,8 +26,8 @@
 #include "fortune.hpp"
 #include "server_lock.hpp"
 
-#include <boost/filesystem.hpp>
-namespace fs = boost::filesystem;
+#include <filesystem>
+namespace fs = std::filesystem;
 
 using namespace budget;
 
@@ -127,17 +127,7 @@ static config_type internal;
 static config_type internal_bak;
 
 bool budget::load_config() {
-    if(!load_configuration(path_to_home_file(".budgetrc"), configuration)){
-        return false;
-    }
-
-    fs::path config_home;
-    if(auto xdg_config_home = std::getenv("XDG_CONFIG_HOME")) {
-        config_home = fs::path{xdg_config_home};
-    } else {
-        config_home = fs::path{home_folder()} / ".config";
-    }
-    if(!load_configuration((config_home / "budget" / "budgetrc").string(), configuration)) {
+    if(!load_configuration(config_file(), configuration)){
         return false;
     }
 
@@ -169,6 +159,22 @@ void budget::save_config() {
 
         LOG_F(INFO, "Save internal configuration");
     }
+}
+
+std::string budget::config_file() {
+    auto old_config = path_to_home_file(".budgetrc");
+    if(file_exists(old_config)) {
+        return old_config;
+    }
+
+    fs::path config_home;
+    if(auto xdg_config_home = std::getenv("XDG_CONFIG_HOME")) {
+        config_home = fs::path{xdg_config_home};
+    } else {
+        config_home = fs::path{home_folder()} / ".config";
+    }
+
+    return (config_home / "budget" / "budgetrc").string();
 }
 
 std::string budget::home_folder() {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -26,6 +26,9 @@
 #include "fortune.hpp"
 #include "server_lock.hpp"
 
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
+
 using namespace budget;
 
 using config_type = std::unordered_map<std::string, std::string>;
@@ -123,7 +126,7 @@ static config_type configuration;
 static config_type internal;
 static config_type internal_bak;
 
-bool budget::load_config(){
+bool budget::load_config() {
     if(!load_configuration(path_to_home_file(".budgetrc"), configuration)){
         return false;
     }
@@ -158,7 +161,7 @@ void budget::save_config() {
     }
 }
 
-std::string budget::home_folder(){
+std::string budget::home_folder() {
 #ifdef _WIN32
     TCHAR path[MAX_PATH];
     if (SUCCEEDED(SHGetFolderPath(NULL, CSIDL_PROFILE, NULL, 0, path))) {
@@ -175,19 +178,28 @@ std::string budget::home_folder(){
 #endif
 }
 
-std::string budget::path_to_home_file(const std::string& file){
-    return home_folder() + "/" + file;
-}
-
-std::string budget::budget_folder(){
-    if(config_contains("directory")){
+std::string budget::budget_folder() {
+    if(config_contains("directory")) {
         return config_value("directory");
     }
 
-    return path_to_home_file(".budget");
+    auto old_home = path_to_home_file(".budget");
+    if(file_exists(old_home)) {
+        return old_home;
+    }
+
+    if(auto data_home = std::getenv("XDG_DATA_HOME")) {
+        return (fs::path{data_home} / "budget").string();
+    }
+
+    return home_folder() + "/.local/share/budget";
+}
+ 
+std::string budget::path_to_home_file(const std::string& file) {
+    return home_folder() + "/" + file;
 }
 
-std::string budget::path_to_budget_file(const std::string& file){
+std::string budget::path_to_budget_file(const std::string& file) {
     return budget_folder() + "/" + file;
 }
 


### PR DESCRIPTION
Should be fully backwards-compatible:
- the config from `XDG_CONFIG_HOME/budget/budgetrc` is simply loaded after `~/.budgetrc`, thus taking precedence
- the data uses `~/.budget` if it exists and XDG otherwise

Adds dependency on `boost::filesystem` - it could be made to work without, but it is safer this way, since we don't know whether the environment variables contain a trailing slash.

Note that my experience with C++ is very limited, but everything seems to behave as expected and the code also looks good to me.

Fixes #18