### PR TITLE
Fixes to support building on MacOS clang (catalina)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.8)
 project (budgetwarrier)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_INSTALL_PREFIX /usr/local)
@@ -11,6 +11,8 @@ set(warnings "-Wall -Wextra -Werror")
 find_package(OpenSSL REQUIRED)
 
 include_directories(include)
+include_directories(loguru)
+include_directories(fmt/include)
 include_directories(cpp-httplib)
 include_directories(${OPENSSL_INCLUDE_DIR})
 

--- a/include/data_cache.hpp
+++ b/include/data_cache.hpp
@@ -20,7 +20,7 @@
 #include "objectives.hpp"
 #include "expenses.hpp"
 #include "wishes.hpp"
-#include "unordered_map"
+#include <unordered_map>
 
 namespace budget {
 

--- a/include/data_cache.hpp
+++ b/include/data_cache.hpp
@@ -20,6 +20,7 @@
 #include "objectives.hpp"
 #include "expenses.hpp"
 #include "wishes.hpp"
+#include "unordered_map"
 
 namespace budget {
 

--- a/include/objectives.hpp
+++ b/include/objectives.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <array>
 
 #include "module_traits.hpp"
 #include "money.hpp"

--- a/src/budget.cpp
+++ b/src/budget.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <iostream>
 #include <tuple>
+#include <unordered_map>
 
 #include "cpp_utils/tmp.hpp"
 

--- a/src/currency.cpp
+++ b/src/currency.cpp
@@ -8,6 +8,7 @@
 #include <tuple>
 #include <utility>
 #include <iostream>
+#include <unordered_map>
 
 #include "currency.hpp"
 #include "assets.hpp" // For get_default_currency

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -6,6 +6,7 @@
 //=======================================================================
 
 #include <charconv>
+#include <array>
 
 #include "data.hpp"
 #include "utils.hpp"

--- a/src/fortune.cpp
+++ b/src/fortune.cpp
@@ -99,9 +99,9 @@ void budget::status_fortunes(budget::writer& w, bool short_view){
                     contents.push_back({"", to_string(fortune.check_date), to_string(fortune.amount), "", "", "", "", "", "::edit::fortunes::" + budget::to_string(fortune.id)});
                 }
             } else if (i == 1) {
-                auto diff = fortune.amount - previous;
-                auto d    = fortune.check_date - previous_date;
-                auto avg  = diff / d;
+                money diff = fortune.amount - previous;
+                long d     = fortune.check_date - previous_date;
+                money avg  = diff / d;
 
                 if (short_view) {
                     contents.push_back({to_string(previous_date), to_string(fortune.check_date), to_string(fortune.amount),
@@ -111,13 +111,13 @@ void budget::status_fortunes(budget::writer& w, bool short_view){
                                         format_money(diff), to_string(d), to_string(avg), "", "", "::edit::fortunes::" + budget::to_string(fortune.id)});
                 }
             } else {
-                auto diff = fortune.amount - previous;
-                auto d    = fortune.check_date - previous_date;
-                auto avg  = diff / d;
+                money diff = fortune.amount - previous;
+                long d     = fortune.check_date - previous_date;
+                money avg  = diff / d;
 
-                auto tot_diff = fortune.amount - first;
-                auto tot_d    = fortune.check_date - first_date;
-                auto tot_avg  = tot_diff / tot_d;
+                money tot_diff = fortune.amount - first;
+                long  tot_d    = fortune.check_date - first_date;
+                money tot_avg  = tot_diff / tot_d;
 
                 if (short_view) {
                     contents.push_back({to_string(previous_date), to_string(fortune.check_date), to_string(fortune.amount),

--- a/src/money.cpp
+++ b/src/money.cpp
@@ -8,6 +8,7 @@
 #include <stdexcept>
 #include <random>
 #include <charconv>
+#include <array>
 
 #include "money.hpp"
 #include "utils.hpp"


### PR DESCRIPTION
- Added packages to CMakeLists.txt so they are found in include path by compiler
- Missing include files in various compilation units
- Fixes to fully support C++17
- Fixes for compiler overload errors