### PR TITLE
Fix macOS build compilation errors

### DIFF
--- a/include/views.hpp
+++ b/include/views.hpp
@@ -11,6 +11,9 @@
 
 #include "date.hpp"
 #include "assets.hpp"
+#ifdef __APPLE__
+#include "accounts.hpp"
+#endif
 #include "expenses.hpp"
 #include "liabilities.hpp"
 

--- a/src/money.cpp
+++ b/src/money.cpp
@@ -125,7 +125,11 @@ std::string budget::random_name(size_t length){
     static std::random_device rd;
     static std::mt19937_64 engine(rd());
 
+#ifdef __APPLE__
+    std::uniform_int_distribution<int> letters_dist(0, 25);
+#else
     std::uniform_int_distribution<char> letters_dist(0, 25);
+#endif
 
     std::string name;
 

--- a/src/share.cpp
+++ b/src/share.cpp
@@ -10,6 +10,7 @@
 #include <math.h>
 
 #include <chrono>
+#include <ctime>
 #include <iostream>
 #include <map>
 #include <set>
@@ -53,6 +54,18 @@ budget::server_lock shares_lock;
 budget::date get_valid_date(const budget::date & d){
     // We cannot get closing price in the future, so we use the day before date
     if (d >= budget::local_day()) {
+#ifdef __APPLE__
+        const auto now  = std::time(nullptr);
+        const auto tm   = std::localtime(&now);
+
+        // We make sure that we are on a new U.S: day
+        // TODO This should be done by getting the current time in the U.S.
+        if (tm->tm_hour > 15) {
+            return get_valid_date(budget::local_day() - budget::days(1));
+        }
+
+        return get_valid_date(budget::local_day() - budget::days(2));
+#else
         const auto now  = std::chrono::system_clock::now();
         const auto zone = std::chrono::current_zone();
         const auto time = zone->to_local(now);
@@ -66,6 +79,7 @@ budget::date get_valid_date(const budget::date & d){
         }
 
         return get_valid_date(budget::local_day() - budget::days(2));
+#endif
     }
 
     if (auto dow = d.day_of_the_week(); dow == 6 || dow == 7){


### PR DESCRIPTION
Fix three compilation errors that prevent building on macOS:

1. uniform_int_distribution<char> is invalid on modern C++ standard libraries - changed to int on macOS
2. Forward declaration of account struct doesn't provide complete type for std::ranges::find_if - added #include "accounts.hpp" on macOS
3. std::chrono::current_zone() is not available on macOS - use std::time() and std::localtime() as portable alternative on macOS

All changes are conditional using #ifdef __APPLE__ to apply fixes only on macOS, preserving original code for Linux builds.